### PR TITLE
test(adapter-*): fix adapters compatibility cases

### DIFF
--- a/docs/guides/intro-to-graphql.md
+++ b/docs/guides/intro-to-graphql.md
@@ -428,3 +428,399 @@ keystone.extendGraphQLSchema({
   ],
 });
 ```
+
+## Filter semantics
+
+This section defines the expected semantics of generated `where` filters.
+
+### Boolean composition
+
+A `where` object is evaluated as an implicit `AND` of all fields inside that object.
+
+Example:
+
+```json
+{
+  "name": "Alice",
+  "age": 20
+}
+```
+
+means: `name = Alice AND age = 20`
+
+Logical operators are also combined with sibling fields using implicit `AND`.
+
+Example:
+
+```js
+{
+  name_contains: 'i',
+  AND: [{ age_gt: 25 }],
+  OR: [{ company_is_null: true }],
+}
+```
+
+means:
+
+```txt
+name contains "i"
+AND age > 25
+AND company is null
+```
+
+### `AND` semantics
+
+`AND` accepts a list of `where` objects.
+
+```js
+{ AND: [A, B, C] }
+```
+
+means:
+
+```txt
+A AND B AND C AND true
+```
+
+An empty `AND` is always true:
+
+```js
+{ AND: [] }
+```
+
+matches every item.
+
+This is the identity element of conjunction.
+
+### `OR` semantics
+
+`OR` accepts a list of `where` objects.
+
+```js
+{ OR: [A, B, C] }
+```
+
+means:
+
+```txt
+A OR B OR C OR false
+```
+
+An empty `OR` is always false:
+
+```js
+{ OR: [] }
+```
+
+matches no items.
+
+This is the identity element of disjunction over an empty list.
+
+### Empty `where` object
+
+An empty `where` object is always true:
+
+```js
+{}
+```
+
+matches every item.
+
+Therefore:
+
+```js
+{ AND: [{}] }
+```
+
+matches every item.
+
+And:
+
+```js
+{ OR: [{}] }
+```
+
+also matches every item.
+
+### To-one relationship filters
+
+For a to-one relationship, a nested relationship filter matches only if the related item exists and satisfies the nested predicate.
+
+Example:
+
+```js
+{
+  company: { name: 'Thinkmill' }
+}
+```
+
+means:
+
+```txt
+user.company exists
+AND user.company.name = Thinkmill
+```
+
+An empty nested predicate on a to-one relationship means “relationship exists”:
+
+```js
+{
+  company: {}
+}
+```
+
+matches users with a non-null `company`.
+
+The same applies to:
+
+```js
+{
+  company: { AND: [] }
+}
+```
+
+because `AND: []` is true, but the related item must still exist.
+
+This does not match users where `company` is null.
+
+A nested empty `OR` is false:
+
+```js
+{
+  company: { OR: [] }
+}
+```
+
+matches no users.
+
+To check nullability explicitly, use:
+
+```js
+{ company_is_null: true }
+{ company_is_null: false }
+```
+
+### To-many relationship filters
+
+For a to-many relationship, the generated filters are interpreted as quantifiers over related items.
+
+Given:
+
+```js
+posts_some: P
+posts_none: P
+posts_every: P
+```
+
+where `P` is a nested `where` predicate over `Post`.
+
+#### `some`
+
+```js
+{
+  posts_some: P
+}
+```
+
+means:
+
+```txt
+there exists at least one related post that satisfies P
+```
+
+Equivalent logical form:
+
+```txt
+EXISTS post WHERE P(post)
+```
+
+Therefore:
+
+```js
+{
+  posts_some: {}
+}
+```
+
+means “has at least one related post”.
+
+#### `none`
+
+```js
+{
+  posts_none: P
+}
+```
+
+means:
+
+```txt
+there is no related post that satisfies P
+```
+
+Equivalent logical form:
+
+```txt
+NOT EXISTS post WHERE P(post)
+```
+
+Therefore:
+
+```js
+{
+  posts_none: {}
+}
+```
+
+means “has no related posts”.
+
+#### `every`
+
+```js
+{
+  posts_every: P
+}
+```
+
+means:
+
+```txt
+every related post satisfies P
+```
+
+Equivalent logical form:
+
+```txt
+NOT EXISTS post WHERE NOT P(post)
+```
+
+`every` is true for an empty relationship.
+
+This is intentional: if there are no related posts, there is no related post that violates the predicate.
+
+Therefore:
+
+```js
+{
+  posts_every: { content: 'Hello' }
+}
+```
+
+matches users where either:
+
+```txt
+all related posts have content = Hello
+OR the user has no related posts
+```
+
+To require at least one related item, combine `every` with `some: {}`:
+
+```js
+{
+  AND: [
+    { posts_every: { content: 'Hello' } },
+    { posts_some: {} },
+  ],
+}
+```
+
+This means:
+
+```txt
+user has at least one post
+AND every post has content = Hello
+```
+
+### Scope of nested predicates inside relationship filters
+
+Inside a single relationship quantifier, all nested conditions apply to the same related item for `some`, and to each individual related item for `every` / `none`.
+
+Example:
+
+```js
+{
+  posts_some: {
+    AND: [
+      { content: 'Hello' },
+      { content: 'World' },
+    ],
+  },
+}
+```
+
+means:
+
+```txt
+there exists one same post where content = Hello AND content = World
+```
+
+This must not be interpreted as:
+
+```txt
+there exists one post with content = Hello
+AND there exists another post with content = World
+```
+
+To express conditions that may match different related items, use multiple relationship filters at the parent level:
+
+```js
+{
+  AND: [
+    { posts_some: { content: 'Hello' } },
+    { posts_some: { content: 'World' } },
+  ],
+}
+```
+
+This means:
+
+```txt
+there exists a related post with content = Hello
+AND there exists a related post with content = World
+```
+
+The two `posts_some` filters may match different related posts.
+
+### Multiple quantifiers on the same relationship
+
+Multiple filters on the same relationship MUST be evaluated as independent quantifiers over the same relationship.
+
+Example:
+
+```js
+{
+  AND: [
+    { posts_every: { content: 'Hello' } },
+    { posts_none: { content: 'Hello' } },
+  ],
+}
+```
+
+means:
+
+```txt
+every related post has content = Hello
+AND no related post has content = Hello
+```
+
+This matches only items with no related posts.
+
+Example:
+
+```js
+{
+  OR: [
+    { posts_every: { content: 'Hello' } },
+    { posts_none: { content: 'Hello' } },
+  ],
+}
+```
+
+means:
+
+```txt
+all related posts are Hello
+OR no related posts are Hello
+```
+
+This must preserve both branches independently. Conditions from one branch MUST NOT leak into another branch.

--- a/docs/guides/intro-to-graphql.md
+++ b/docs/guides/intro-to-graphql.md
@@ -472,7 +472,7 @@ AND company is null
 
 `AND` accepts a list of `where` objects.
 
-```js
+```text
 { AND: [A, B, C] }
 ```
 
@@ -484,7 +484,7 @@ A AND B AND C AND true
 
 An empty `AND` is always true:
 
-```js
+```text
 { AND: [] }
 ```
 
@@ -496,7 +496,7 @@ This is the identity element of conjunction.
 
 `OR` accepts a list of `where` objects.
 
-```js
+```text
 { OR: [A, B, C] }
 ```
 
@@ -508,7 +508,7 @@ A OR B OR C OR false
 
 An empty `OR` is always false:
 
-```js
+```text
 { OR: [] }
 ```
 
@@ -520,7 +520,7 @@ This is the identity element of disjunction over an empty list.
 
 An empty `where` object is always true:
 
-```js
+```text
 {}
 ```
 
@@ -528,7 +528,7 @@ matches every item.
 
 Therefore:
 
-```js
+```text
 { AND: [{}] }
 ```
 
@@ -536,7 +536,7 @@ matches every item.
 
 And:
 
-```js
+```text
 { OR: [{}] }
 ```
 
@@ -548,7 +548,7 @@ For a to-one relationship, a nested relationship filter matches only if the rela
 
 Example:
 
-```js
+```text
 {
   company: { name: 'Thinkmill' }
 }
@@ -563,7 +563,7 @@ AND user.company.name = Thinkmill
 
 An empty nested predicate on a to-one relationship means “relationship exists”:
 
-```js
+```text
 {
   company: {}
 }
@@ -573,7 +573,7 @@ matches users with a non-null `company`.
 
 The same applies to:
 
-```js
+```text
 {
   company: { AND: [] }
 }
@@ -585,7 +585,7 @@ This does not match users where `company` is null.
 
 A nested empty `OR` is false:
 
-```js
+```text
 {
   company: { OR: [] }
 }
@@ -595,7 +595,7 @@ matches no users.
 
 To check nullability explicitly, use:
 
-```js
+```text
 { company_is_null: true }
 { company_is_null: false }
 ```
@@ -606,7 +606,7 @@ For a to-many relationship, the generated filters are interpreted as quantifiers
 
 Given:
 
-```js
+```text
 posts_some: P
 posts_none: P
 posts_every: P
@@ -616,7 +616,7 @@ where `P` is a nested `where` predicate over `Post`.
 
 #### `some`
 
-```js
+```text
 {
   posts_some: P
 }
@@ -636,7 +636,7 @@ EXISTS post WHERE P(post)
 
 Therefore:
 
-```js
+```text
 {
   posts_some: {}
 }
@@ -646,7 +646,7 @@ means “has at least one related post”.
 
 #### `none`
 
-```js
+```text
 {
   posts_none: P
 }
@@ -666,7 +666,7 @@ NOT EXISTS post WHERE P(post)
 
 Therefore:
 
-```js
+```text
 {
   posts_none: {}
 }
@@ -676,7 +676,7 @@ means “has no related posts”.
 
 #### `every`
 
-```js
+```text
 {
   posts_every: P
 }
@@ -700,7 +700,7 @@ This is intentional: if there are no related posts, there is no related post tha
 
 Therefore:
 
-```js
+```text
 {
   posts_every: { content: 'Hello' }
 }

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -834,6 +834,9 @@ class QueryBuilder {
           }
           where[path].forEach(subWhere => {
             subJoiner(q => {
+              // Each element in the AND/OR array must be wrapped in its own subquery.
+              // This ensures that multiple conditions within a single element (implicit AND)
+              // are correctly scoped and combined with AND, regardless of the outer operator.
               q.whereRaw('true');
               this._addWheres(w => q.andWhere(w), listAdapter, subWhere, tableAlias);
             });
@@ -845,7 +848,20 @@ class QueryBuilder {
         if (fieldAdapter) {
           // Non-many relationship. Traverse the sub-query, using the referenced list as a root.
           const otherListAdapter = listAdapter.getListAdapterByKey(fieldAdapter.refListKey);
-          this._addWheres(whereJoiner, otherListAdapter, where[path], `${tableAlias}__${path}`);
+          whereJoiner(q => {
+            // For to-one relationships, if a filter is provided (even an empty object),
+            // we must ensure that the relationship exists (i.e., the foreign key is not null).
+            // This behavior is consistent with Mongoose and Prisma adapters.
+            if (
+              fieldAdapter.rel.cardinality === '1:1' &&
+              fieldAdapter.rel.right === fieldAdapter.field
+            ) {
+              q.whereNotNull(`${tableAlias}__${fieldAdapter.path}.id`);
+            } else {
+              q.whereNotNull(`${tableAlias}.${fieldAdapter.dbPath}`);
+            }
+            this._addWheres(w => q.andWhere(w), otherListAdapter, where[path], `${tableAlias}__${path}`);
+          });
         } else {
           // Many relationship
           const [p, constraintType] = path.split('_');

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -832,9 +832,12 @@ class QueryBuilder {
               'Unknown add wheres condition. If you are trying to implement NOT, you are in the right place'
             );
           }
-          where[path].forEach(subWhere =>
-            this._addWheres(subJoiner, listAdapter, subWhere, tableAlias)
-          );
+          where[path].forEach(subWhere => {
+            subJoiner(q => {
+              q.whereRaw('true');
+              this._addWheres(w => q.andWhere(w), listAdapter, subWhere, tableAlias);
+            });
+          });
         });
       } else {
         // We have a relationship field

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -860,7 +860,12 @@ class QueryBuilder {
             } else {
               q.whereNotNull(`${tableAlias}.${fieldAdapter.dbPath}`);
             }
-            this._addWheres(w => q.andWhere(w), otherListAdapter, where[path], `${tableAlias}__${path}`);
+            this._addWheres(
+              w => q.andWhere(w),
+              otherListAdapter,
+              where[path],
+              `${tableAlias}__${path}`
+            );
           });
         } else {
           // Many relationship

--- a/packages/adapter-mongoose/lib/query-parser.js
+++ b/packages/adapter-mongoose/lib/query-parser.js
@@ -8,8 +8,12 @@ const {
 } = require('./tokenizers');
 
 // If it's 0 or 1 items, we can use it as-is. Any more needs an $and/$or
-const joinTerms = (matchTerms, joinOp) =>
-  matchTerms.length > 1 ? { [joinOp]: matchTerms } : matchTerms[0];
+const joinTerms = (matchTerms, joinOp) => {
+  if (matchTerms.length === 0) {
+    return joinOp === '$or' ? { _id: { $exists: false } } : undefined;
+  }
+  return matchTerms.length > 1 ? { [joinOp]: matchTerms } : matchTerms[0];
+};
 
 const flattenQueries = (parsedQueries, joinOp) => ({
   matchTerm: joinTerms(

--- a/packages/adapter-mongoose/lib/query-parser.js
+++ b/packages/adapter-mongoose/lib/query-parser.js
@@ -10,7 +10,7 @@ const {
 // If it's 0 or 1 items, we can use it as-is. Any more needs an $and/$or
 const joinTerms = (matchTerms, joinOp) => {
   if (matchTerms.length === 0) {
-    return joinOp === '$or' ? { _id: { $exists: false } } : undefined;
+    return joinOp === '$or' ? { _id: { $exists: false } } : {};
   }
   return matchTerms.length > 1 ? { [joinOp]: matchTerms } : matchTerms[0];
 };

--- a/packages/adapter-mongoose/tests/query-parser.test.js
+++ b/packages/adapter-mongoose/tests/query-parser.test.js
@@ -145,7 +145,7 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: [
           {
-            matchTerm: undefined,
+            matchTerm: {},
             relationshipInfo: {
               from: 'posts',
               uniqueField: 'posts_posts',
@@ -559,7 +559,7 @@ describe('query parser', () => {
       const queryTree = queryParser({ listAdapter, getUID: k => k }, query, ['broken']);
       expect(queryTree).toMatchObject({
         relationships: [],
-        matchTerm: undefined,
+        matchTerm: {},
       });
     });
   });

--- a/packages/adapter-prisma/lib/adapter-prisma.js
+++ b/packages/adapter-prisma/lib/adapter-prisma.js
@@ -512,7 +512,14 @@ class PrismaListAdapter extends BaseListAdapter {
       .map(([condition, value]) => {
         if (condition === 'AND' || condition === 'OR') {
           const processed = value.map(w => this.processWheres(w)).filter(w => w !== undefined);
-          return processed.length > 0 ? { [condition]: processed } : undefined;
+          if (processed.length > 0) {
+            return { [condition]: processed };
+          }
+          if (condition === 'OR') {
+            const idField = this.fieldAdapters.find(a => a.field.isPrimaryKey);
+            return { [idField ? idField.path : 'id']: { in: [] } };
+          }
+          return undefined;
         } else if (
           this.fieldAdaptersByPath[condition] &&
           this.fieldAdaptersByPath[condition].isRelationship

--- a/packages/adapter-prisma/lib/adapter-prisma.js
+++ b/packages/adapter-prisma/lib/adapter-prisma.js
@@ -511,15 +511,23 @@ class PrismaListAdapter extends BaseListAdapter {
     const wheres = Object.entries(where)
       .map(([condition, value]) => {
         if (condition === 'AND' || condition === 'OR') {
-          const processed = value.map(w => this.processWheres(w)).filter(w => w !== undefined);
-          if (processed.length > 0) {
-            return { [condition]: processed };
-          }
+          const processed = value.map(w => this.processWheres(w));
           if (condition === 'OR') {
-            const idField = this.fieldAdapters.find(a => a.field.isPrimaryKey);
-            return { [idField ? idField.path : 'id']: { in: [] } };
+            if (processed.length === 0) {
+              const idField = this.fieldAdapters.find(a => a.field.isPrimaryKey);
+              return { [idField ? idField.path : 'id']: { in: [] } };
+            }
+            if (processed.some(w => w === undefined)) {
+              return undefined;
+            }
+            return { OR: processed };
+          } else {
+            const filtered = processed.filter(w => w !== undefined);
+            if (filtered.length === 0) {
+              return undefined;
+            }
+            return filtered.length === 1 ? filtered[0] : { AND: filtered };
           }
-          return undefined;
         } else if (
           this.fieldAdaptersByPath[condition] &&
           this.fieldAdaptersByPath[condition].isRelationship
@@ -545,9 +553,13 @@ class PrismaListAdapter extends BaseListAdapter {
             // Many relationship
             const [fieldPath, constraintType] = condition.split('_');
             const processed = processRelClause(fieldPath, value);
-            return processed !== undefined
-              ? { [fieldPath]: { [constraintType]: processed } }
-              : undefined;
+            if (processed !== undefined) {
+              return { [fieldPath]: { [constraintType]: processed } };
+            }
+            if (constraintType === 'some' || constraintType === 'none') {
+              return { [fieldPath]: { [constraintType]: {} } };
+            }
+            return undefined;
           }
         }
       })

--- a/packages/adapter-prisma/lib/adapter-prisma.js
+++ b/packages/adapter-prisma/lib/adapter-prisma.js
@@ -534,7 +534,12 @@ class PrismaListAdapter extends BaseListAdapter {
         ) {
           // Non-many relationship. Traverse the sub-query, using the referenced list as a root.
           const processed = processRelClause(condition, value);
-          return processed !== undefined ? { [condition]: processed } : undefined;
+          if (processed !== undefined) {
+            return { [condition]: processed };
+          }
+          // If we have an empty filter on a to-one relationship, we still want to
+          // enforce that the relationship exists (is not null).
+          return { [condition]: { isNot: null } };
         } else {
           // See if any of our fields know what to do with this condition
           let dbPath = condition;

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -995,10 +995,11 @@ module.exports = class List {
         }`,
 
         // https://github.com/opencrud/opencrud/blob/master/spec/2-relational/2-2-queries/2-2-3-filters.md#boolean-expressions
+        // https://github.com/opencrud/opencrud/pull/47
         `
         input ${this.gqlNames.whereInputName} {
-          AND: [${this.gqlNames.whereInputName}]
-          OR: [${this.gqlNames.whereInputName}]
+          AND: [${this.gqlNames.whereInputName}!]
+          OR: [${this.gqlNames.whereInputName}!]
 
           ${flatten(readFields.map(field => field.gqlQueryInputFields({ schemaName }))).join('\n')}
         }`,

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -490,8 +490,8 @@ describe(`getGqlTypes()`, () => {
         writeOnce: String
       }`;
   const whereInput = `input TestWhereInput {
-        AND: [TestWhereInput]
-        OR: [TestWhereInput]
+        AND: [TestWhereInput!]
+        OR: [TestWhereInput!]
         id: ID
         name: String
         name_not: String

--- a/tests/api-tests/queries/complex-filters.test.js
+++ b/tests/api-tests/queries/complex-filters.test.js
@@ -1,0 +1,257 @@
+const { multiAdapterRunners, setupServer } = require('@open-keystone/test-utils');
+const { Text, Integer, Relationship } = require('@open-keystone/fields');
+const { createItem } = require('@open-keystone/server-side-graphql-client');
+
+const setupKeystone = adapterName =>
+  setupServer({
+    adapterName,
+    createLists: keystone => {
+      keystone.createList('User', {
+        fields: {
+          name: { type: Text },
+          email: { type: Text },
+          age: { type: Integer },
+          company: { type: Relationship, ref: 'Company' },
+          posts: { type: Relationship, ref: 'Post', many: true },
+        },
+      });
+      keystone.createList('Company', {
+        fields: {
+          name: { type: Text },
+        },
+      });
+      keystone.createList('Post', {
+        fields: {
+          content: { type: Text },
+        },
+      });
+    },
+  });
+
+const complexFilterTests = [
+  {
+    id: 'and_with_scalar_on_same_level',
+    case: 'Scalar field and AND on the same level (implicit AND)',
+    where: { name_contains: 'i', AND: [{ age_gt: 25 }] },
+    expect_ids: ['Charlie', 'David'],
+  },
+  {
+    id: 'or_with_scalar_on_same_level',
+    case: 'Scalar field and OR on the same level (implicit AND)',
+    where: { name: 'Alice', OR: [{ age: 30 }, { age: 20 }] },
+    expect_ids: ['Alice'],
+  },
+  {
+    id: 'and_with_multiple_scalars_implicit',
+    case: 'Multiple scalar fields inside AND (implicit AND)',
+    where: { AND: [{ name_contains: 'a', age_gt: 25 }] },
+    expect_ids: ['Charlie', 'David'],
+  },
+  {
+    id: 'or_with_multiple_scalars_implicit',
+    case: 'Multiple scalar fields inside OR (implicit AND)',
+    where: { OR: [{ name: 'Alice', age: 30 }, { name: 'Bob' }] },
+    expect_ids: ['Bob'],
+  },
+  {
+    id: 'nested_or_inside_and',
+    case: 'Nested OR inside AND',
+    where: { AND: [{ name_contains: 'a' }, { OR: [{ age: 20 }, { age: 50 }] }] },
+    expect_ids: ['David'],
+  },
+  {
+    id: 'nested_and_inside_or',
+    case: 'Nested AND inside OR',
+    where: { OR: [{ AND: [{ name_contains: 'i' }, { age: 20 }] }, { age: 40 }] },
+    expect_ids: ['Alice', 'Charlie'],
+  },
+  {
+    id: 'empty_and',
+    case: 'Empty AND array',
+    where: { AND: [] },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'empty_or',
+    case: 'Empty OR array',
+    where: { OR: [] },
+    expect_ids: [],
+  },
+  {
+    id: 'and_with_relationship_and_scalar',
+    case: 'AND with relationship filter and scalar field',
+    where: { AND: [{ company: { name: 'Thinkmill' } }, { age_lt: 25 }] },
+    expect_ids: ['Alice'],
+  },
+  {
+    id: 'posts_some_with_and',
+    case: 'Relationship posts_some with AND (multiple conditions on SAME post)',
+    where: { posts_some: { AND: [{ content_contains: 'H' }, { content_contains: 'l' }] } },
+    expect_ids: ['Alice', 'Bob'],
+  },
+  {
+    id: 'and_with_multiple_posts_some',
+    case: 'AND with multiple posts_some (conditions on POTENTIALLY DIFFERENT posts)',
+    where: { AND: [{ posts_some: { content: 'Hello' } }, { posts_some: { content: 'World' } }] },
+    expect_ids: ['Alice'],
+  },
+  {
+    id: 'posts_every_with_or',
+    case: 'Relationship posts_every with OR',
+    where: { posts_every: { OR: [{ content: 'Hello' }, { content: 'World' }] } },
+    expect_ids: ['Alice', 'Bob', 'David'],
+  },
+  {
+    id: 'or_with_same_field_repeated',
+    case: 'OR with same field repeated with different conditions',
+    where: { OR: [{ age_lt: 25 }, { age_gt: 45 }] },
+    expect_ids: ['Alice', 'David'],
+  },
+  {
+    id: 'deeply_nested_and_or',
+    case: 'Deeply nested AND/OR',
+    where: {
+      AND: [
+        {
+          OR: [
+            { AND: [{ name: 'Alice' }] },
+            { AND: [{ name: 'Bob' }, { age: 30 }] }
+          ]
+        }
+      ]
+    },
+    expect_ids: ['Alice', 'Bob'],
+  },
+  {
+    id: 'and_with_mixed_fields_inside',
+    case: 'Mixed fields and AND inside AND',
+    where: { AND: [{ name_contains: 'a', AND: [{ age_gt: 25 }] }] },
+    expect_ids: ['Charlie', 'David'],
+  },
+  {
+    id: 'nested_relationship_mixed_and',
+    case: 'Nested relationship with mixed fields and AND',
+    where: { company: { name_contains: 'T', AND: [{ name_contains: 'i' }] } },
+    expect_ids: ['Alice', 'Bob'],
+  },
+  {
+    id: 'implicit_and_in_scalar_filter',
+    case: 'Multiple fields in a single object (implicit AND)',
+    where: { name: 'Alice', age: 30 },
+    expect_ids: [],
+  },
+  {
+    id: 'or_with_nested_and_scalar_mixed',
+    case: 'OR with mixed nested AND and scalar fields',
+    where: { OR: [{ AND: [{ name: 'Alice' }, { age: 30 }] }, { name: 'Bob' }] },
+    expect_ids: ['Bob'],
+  }
+];
+
+const invalidFilterTests = [
+  {
+    id: 'unknown_filter_field',
+    where: { age_between: [20, 30] },
+  },
+  {
+    id: 'wrong_scalar_type',
+    where: { age_gt: '25' },
+  },
+  {
+    id: 'wrong_and_shape',
+    where: { AND: { age: 20 } },
+  },
+  {
+    id: 'null_inside_and_array',
+    where: { AND: [null] },
+  },
+  {
+    id: 'unknown_logical_operator',
+    where: { NOT: [{ name: 'Alice' }] },
+  },
+];
+
+const createFixture = async keystone => {
+  const companies = {};
+  companies.c1 = await createItem({ keystone, listKey: 'Company', item: { name: 'Thinkmill' } });
+  companies.c2 = await createItem({ keystone, listKey: 'Company', item: { name: 'Cete' } });
+
+  const posts = {};
+  posts.p1 = await createItem({ keystone, listKey: 'Post', item: { content: 'Hello' } });
+  posts.p2 = await createItem({ keystone, listKey: 'Post', item: { content: 'World' } });
+  posts.p3 = await createItem({ keystone, listKey: 'Post', item: { content: 'Bye' } });
+
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'Alice',
+      age: 20,
+      email: 'alice@example.com',
+      company: { connect: { id: companies.c1.id } },
+      posts: { connect: [{ id: posts.p1.id }, { id: posts.p2.id }] },
+    },
+  });
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'Bob',
+      age: 30,
+      email: 'bob@example.com',
+      company: { connect: { id: companies.c1.id } },
+      posts: { connect: [{ id: posts.p1.id }] },
+    },
+  });
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'Charlie',
+      age: 40,
+      email: 'charlie@other.com',
+      company: { connect: { id: companies.c2.id } },
+      posts: { connect: [{ id: posts.p3.id }] },
+    },
+  });
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'David',
+      age: 50,
+      email: 'david@example.com',
+      company: null,
+      posts: { connect: [] },
+    },
+  });
+};
+
+multiAdapterRunners().map(({ runner, adapterName }) =>
+  describe(`Adapter: ${adapterName}`, () => {
+    describe('Complex AND/OR filters', () => {
+      const tests = [
+        ...complexFilterTests,
+        // ...invalidFilterTests,
+      ];
+      tests.forEach(({ id, case: title, where, expect_ids, ...expected }) => {
+        test(
+          `${id} : ${title}`,
+          runner(setupKeystone, async ({ keystone }) => {
+            await createFixture(keystone);
+            const { data, errors } = await keystone.executeGraphQL({
+              query: `query($where: UserWhereInput) { allUsers(where: $where) { name } }`,
+              variables: { where },
+            });
+            expect(errors).toBe(undefined);
+            const ids = data.allUsers.map(u => u.name).sort();
+            const result = (
+              adapterName in expected ? expected[adapterName] : expect_ids
+            ).sort();
+            expect(ids).toEqual(result);
+          })
+        );
+      });
+    });
+  })
+);

--- a/tests/api-tests/queries/complex-filters.test.js
+++ b/tests/api-tests/queries/complex-filters.test.js
@@ -519,6 +519,578 @@ const moreAndOrFilterTests = [
   },
 ];
 
+const deepAndOrFilterTests = [
+  {
+    id: 'deep_and_of_or_groups',
+    case: 'Deep AND of OR groups should preserve grouping',
+    where: {
+      AND: [
+        {
+          OR: [{ name: 'Alice' }, { name: 'Bob' }, { name: 'Charlie' }],
+        },
+        {
+          OR: [
+            { AND: [{ age: 20 }, { email_contains: 'example' }] },
+            { AND: [{ age: 40 }, { email_contains: 'other' }] },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Alice', 'Charlie'],
+  },
+
+  {
+    id: 'deep_or_of_and_groups_with_nested_or_guards',
+    case: 'Deep OR of AND groups with nested OR guards',
+    where: {
+      OR: [
+        {
+          AND: [
+            { OR: [{ name: 'Alice' }, { name: 'Bob' }] },
+            { OR: [{ age: 40 }, { company: { name: 'Cete' } }] },
+          ],
+        },
+        {
+          AND: [
+            { OR: [{ name: 'Charlie' }, { name: 'David' }] },
+            { OR: [{ age: 50 }, { email_contains: 'other' }] },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Charlie', 'David'],
+  },
+
+  {
+    id: 'deep_alternating_and_or_four_levels',
+    case: 'Alternating AND/OR across four levels',
+    where: {
+      AND: [
+        {
+          OR: [
+            { name: 'Alice' },
+            {
+              AND: [
+                { OR: [{ name: 'Bob' }, { name: 'Charlie' }] },
+                {
+                  AND: [
+                    { age_gt: 35 },
+                    { OR: [{ email_contains: 'other' }, { company_is_null: true }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          OR: [{ age_lt: 25 }, { age_gt: 35 }],
+        },
+      ],
+    },
+    expect_ids: ['Alice', 'Charlie'],
+  },
+
+  {
+    id: 'deep_or_branch_must_not_leak_partial_matches',
+    case: 'Deep OR branches should not leak partial matches across branches',
+    where: {
+      OR: [
+        {
+          AND: [
+            { name: 'Alice' },
+            {
+              OR: [
+                { AND: [{ age: 30 }, { email_contains: 'example' }] },
+                { AND: [{ age: 40 }, { email_contains: 'other' }] },
+              ],
+            },
+          ],
+        },
+        {
+          AND: [
+            { name: 'Bob' },
+            {
+              OR: [
+                { AND: [{ age: 20 }, { email_contains: 'example' }] },
+                { AND: [{ age: 30 }, { email_contains: 'example' }] },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Bob'],
+  },
+
+  {
+    id: 'deep_root_scalar_and_or_same_level',
+    case: 'Root scalar, AND and OR with deep nested branches should all be combined as implicit AND',
+    where: {
+      name_contains: 'i',
+      AND: [
+        {
+          OR: [
+            {
+              AND: [
+                { age: 20 },
+                { OR: [{ company: { name: 'Thinkmill' } }, { company_is_null: true }] },
+              ],
+            },
+            {
+              AND: [
+                { age: 40 },
+                { OR: [{ company: { name: 'Cete' } }, { company_is_null: true }] },
+              ],
+            },
+            {
+              AND: [
+                { age: 50 },
+                { OR: [{ company: { name: 'Thinkmill' } }, { company_is_null: true }] },
+              ],
+            },
+          ],
+        },
+      ],
+      OR: [{ email_contains: 'other' }, { company_is_null: true }],
+    },
+    expect_ids: ['Charlie', 'David'],
+  },
+
+  {
+    id: 'company_deep_nested_and_or',
+    case: 'Deep nested AND/OR inside to-one relationship filter',
+    where: {
+      company: {
+        AND: [
+          { OR: [{ name: 'Thinkmill' }, { name: 'Cete' }] },
+          {
+            OR: [
+              {
+                AND: [
+                  { name_contains: 'T' },
+                  { OR: [{ name_contains: 'i' }, { name_contains: 'x' }] },
+                ],
+              },
+              {
+                AND: [
+                  { name_contains: 'C' },
+                  { OR: [{ name_contains: 'z' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    expect_ids: ['Alice', 'Bob'],
+  },
+
+  {
+    id: 'posts_some_deep_and_or_same_related_item',
+    case: 'Deep AND/OR inside posts_some should be evaluated against the same related item',
+    where: {
+      posts_some: {
+        AND: [
+          { OR: [{ content: 'Hello' }, { content: 'Bye' }] },
+          { OR: [{ content: 'World' }, { content: 'Bye' }] },
+        ],
+      },
+    },
+    expect_ids: ['Charlie'],
+  },
+
+  {
+    id: 'posts_every_deep_or_of_and',
+    case: 'Deep OR of AND groups inside posts_every',
+    where: {
+      posts_every: {
+        OR: [
+          {
+            AND: [{ content_contains: 'l' }, { content_contains: 'o' }],
+          },
+          {
+            AND: [{ content: 'Missing' }, { content_contains: 'x' }],
+          },
+        ],
+      },
+    },
+    expect_ids: ['Alice', 'Bob', 'David'],
+  },
+
+  {
+    id: 'deep_empty_or_in_dead_or_branch',
+    case: 'Deep empty OR inside one OR branch should not poison other OR branches',
+    where: {
+      OR: [
+        {
+          AND: [{ name: 'Alice' }, { OR: [] }],
+        },
+        {
+          AND: [
+            { name: 'Bob' },
+            {
+              AND: [
+                {
+                  OR: [{ age: 30 }, { age: 40 }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Bob'],
+  },
+
+  {
+    id: 'deep_empty_and_as_true_branch',
+    case: 'Deep empty AND branch should behave as true inside OR',
+    where: {
+      AND: [
+        {
+          OR: [
+            { AND: [] },
+            { AND: [{ name: 'Nobody' }] },
+          ],
+        },
+        {
+          OR: [{ name: 'Alice' }, { name: 'David' }],
+        },
+      ],
+    },
+    expect_ids: ['Alice', 'David'],
+  },
+];
+
+const divergenceAndOrFilterTests = [
+  {
+    id: 'or_of_cross_relation_and_groups',
+    case: 'OR of AND groups with different relationships should not leak conditions between branches',
+    where: {
+      OR: [
+        {
+          AND: [
+            { company: { name: 'Thinkmill' } },
+            { posts_some: { content: 'World' } },
+          ],
+        },
+        {
+          AND: [
+            { company: { name: 'Cete' } },
+            { posts_some: { content: 'Hello' } },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Alice'],
+  },
+
+  {
+    id: 'or_impossible_posts_some_branch_plus_valid_scalar',
+    case: 'Impossible posts_some branch inside OR should not leak a match from different posts',
+    where: {
+      OR: [
+        { posts_some: { AND: [{ content: 'Hello' }, { content: 'World' }] } },
+        { name: 'David' },
+      ],
+    },
+    expect_ids: ['David'],
+  },
+
+  {
+    id: 'and_impossible_posts_some_or_valid_scalar_under_null_guard',
+    case: 'Impossible posts_some branch inside OR combined with root AND guard',
+    where: {
+      AND: [
+        {
+          OR: [
+            { posts_some: { AND: [{ content: 'Hello' }, { content: 'World' }] } },
+            { name: 'David' },
+          ],
+        },
+        { company_is_null: true },
+      ],
+    },
+    expect_ids: ['David'],
+  },
+  {
+    id: 'and_impossible_posts_some_or_valid_scalar_under_null_guard2',
+    case: 'Impossible posts_some branch inside OR combined with root AND guard',
+    where: {
+      AND: [
+        {
+          OR: [
+            { posts_some: { AND: [{ content: 'Hello' }, { content: 'World' }] } },
+            { name: 'David' },
+          ],
+        },
+        { company_is_null: false },
+      ],
+    },
+    expect_ids: [],
+  },
+
+  {
+    id: 'and_repeated_same_relationship_some_none',
+    case: 'AND with posts_some and posts_none on same relationship should use independent aliases correctly',
+    where: {
+      AND: [
+        { posts_some: { OR: [{ content: 'Hello' }, { content: 'World' }] } },
+        { posts_none: { content: 'Bye' } },
+      ],
+    },
+    expect_ids: ['Alice', 'Bob'],
+  },
+
+  {
+    id: 'or_every_or_none_same_relationship',
+    case: 'OR with posts_every and posts_none on same relationship',
+    where: {
+      OR: [
+        { posts_every: { content: 'Hello' } },
+        { posts_none: { content: 'Hello' } },
+      ],
+    },
+    expect_ids: ['Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'or_every_and_none_same_relationship',
+    case: 'OR with posts_every and posts_none on same relationship',
+    where: {
+      AND: [
+        { posts_every: { content: 'Hello' } },
+        { posts_none: { content: 'Hello' } },
+      ],
+    },
+    expect_ids: ['David'],
+  },
+  {
+    id: 'and_some_every_or_restricts_mixed_posts',
+    case: 'posts_some + posts_every should exclude users with an extra non-matching related item',
+    where: {
+      AND: [
+        { posts_some: { OR: [{ content: 'Hello' }, { content: 'Bye' }] } },
+        { posts_every: { OR: [{ content: 'Hello' }, { content: 'Bye' }] } },
+      ],
+    },
+    expect_ids: ['Bob', 'Charlie'],
+  },
+
+  {
+    id: 'company_empty_and_non_null_relationship',
+    case: 'To-one relationship with empty AND should match users having a related company',
+    where: {
+      company: { AND: [] },
+    },
+    expect_ids: ['Alice', 'Bob', 'Charlie'],
+  },
+
+  {
+    id: 'company_empty_or_matches_no_non_null_company',
+    case: 'To-one relationship with empty OR should match nothing',
+    where: {
+      company: { OR: [] },
+    },
+    expect_ids: [],
+  },
+
+  {
+    id: 'or_company_empty_and_or_null_covers_all',
+    case: 'company empty AND plus company_is_null should cover all users',
+    where: {
+      OR: [
+        { company: { AND: [] } },
+        { company_is_null: true },
+      ],
+    },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+
+  {
+    id: 'and_company_null_and_empty_and_contradiction',
+    case: 'company_is_null and company empty AND should be contradictory',
+    where: {
+      AND: [
+        { company_is_null: true },
+        { company: { AND: [] } },
+      ],
+    },
+    expect_ids: [],
+  },
+
+  {
+    id: 'or_branch_scalar_plus_or_same_level_false_branch',
+    case: 'Scalar and OR on same level inside OR branch should be implicit AND',
+    where: {
+      OR: [
+        {
+          name: 'Alice',
+          OR: [{ age: 30 }, { age: 40 }],
+        },
+        { name: 'Bob' },
+      ],
+    },
+    expect_ids: ['Bob'],
+  },
+
+  {
+    id: 'and_branch_scalar_plus_or_same_level',
+    case: 'Scalar and OR on same level inside AND branch should be implicit AND',
+    where: {
+      AND: [
+        {
+          OR: [{ name: 'Alice' }, { name: 'Bob' }, { name: 'Charlie' }],
+        },
+        {
+          age_gt: 25,
+          OR: [
+            { email_contains: 'other' },
+            { company: { name: 'Thinkmill' } },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Bob', 'Charlie'],
+  },
+
+  {
+    id: 'or_with_same_relationship_in_separate_and_branches',
+    case: 'Same relationship used in separate OR branches should keep branch-local conditions',
+    where: {
+      OR: [
+        {
+          AND: [
+            { posts_some: { content: 'Hello' } },
+            { age: 20 },
+          ],
+        },
+        {
+          AND: [
+            { posts_some: { content: 'Bye' } },
+            { age: 40 },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Alice', 'Charlie'],
+  },
+
+  {
+    id: 'or_scalar_branch_with_multi_row_relationship_branch_no_duplicates',
+    case: 'OR with scalar branch and multi-row relationship branch should not duplicate users',
+    where: {
+      OR: [
+        { name: 'Alice' },
+        { posts_some: { content_contains: 'o' } },
+      ],
+    },
+    expect_ids: ['Alice', 'Bob'],
+  },
+
+  {
+    id: 'and_same_relationship_multiple_matching_rows_no_duplicates',
+    case: 'AND with relationship branch matching multiple related rows should not duplicate user',
+    where: {
+      AND: [
+        { name: 'Alice' },
+        {
+          posts_some: {
+            OR: [
+              { content_contains: 'o' },
+              { content_contains: 'l' },
+            ],
+          },
+        },
+      ],
+    },
+    expect_ids: ['Alice'],
+  },
+
+  {
+    id: 'posts_every_deep_and_of_or_groups',
+    case: 'posts_every with AND of OR groups should preserve every semantics',
+    where: {
+      posts_every: {
+        AND: [
+          { OR: [{ content: 'Hello' }, { content: 'World' }] },
+          { OR: [{ content_contains: 'o' }] },
+        ],
+      },
+    },
+    expect_ids: ['Alice', 'Bob', 'David'],
+  },
+
+  {
+    id: 'posts_none_deep_or_of_and_groups',
+    case: 'posts_none with OR of AND groups should apply anti-join correctly',
+    where: {
+      posts_none: {
+        OR: [
+          {
+            AND: [
+              { content_contains: 'H' },
+              { content_contains: 'e' },
+            ],
+          },
+          {
+            AND: [
+              { content: 'Bye' },
+              { OR: [{ content_contains: 'y' }] },
+            ],
+          },
+        ],
+      },
+    },
+    expect_ids: ['David'],
+  },
+
+  {
+    id: 'posts_some_or_impossible_and_plus_possible_and',
+    case: 'posts_some OR should ignore impossible AND branch and match possible branch on same item',
+    where: {
+      posts_some: {
+        OR: [
+          {
+            AND: [
+              { content: 'Hello' },
+              { content: 'World' },
+            ],
+          },
+          {
+            AND: [
+              { content: 'Bye' },
+              { content_contains: 'y' },
+            ],
+          },
+        ],
+      },
+    },
+    expect_ids: ['Charlie'],
+  },
+
+  {
+    id: 'or_repeated_to_one_relationship_contradiction_plus_live_branch',
+    case: 'Repeated to-one relationship filters in one AND branch should refer to the same related item',
+    where: {
+      OR: [
+        {
+          AND: [
+            { company: { name: 'Thinkmill' } },
+            { company: { name: 'Cete' } },
+          ],
+        },
+        {
+          AND: [
+            { posts_some: { content: 'Bye' } },
+            { name_contains: 'a' },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Charlie'],
+  },
+];
+
 const invalidFilterTests = [
   {
     id: 'unknown_filter_field',
@@ -600,7 +1172,13 @@ const setupKeystone = adapterName =>
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
     describe('Complex AND/OR filters', () => {
-      const cases = [...complexFilterTests, ...extraComplexFilterTests, ...moreAndOrFilterTests];
+      const cases = [
+        ...complexFilterTests,
+        ...extraComplexFilterTests,
+        ...moreAndOrFilterTests,
+        ...deepAndOrFilterTests,
+        ...divergenceAndOrFilterTests,
+      ];
       cases.forEach(({ id, case: title, where, expect_ids, ...expected }) => {
         test(
           `Valid: ${id} : ${title}`,

--- a/tests/api-tests/queries/complex-filters.test.js
+++ b/tests/api-tests/queries/complex-filters.test.js
@@ -851,7 +851,7 @@ const divergenceAndOrFilterTests = [
   },
   {
     id: 'or_every_and_none_same_relationship',
-    case: 'OR with posts_every and posts_none on same relationship',
+    case: 'AND with posts_every and posts_none on same relationship',
     where: {
       AND: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'Hello' } }],
     },

--- a/tests/api-tests/queries/complex-filters.test.js
+++ b/tests/api-tests/queries/complex-filters.test.js
@@ -683,10 +683,7 @@ const deepAndOrFilterTests = [
                 ],
               },
               {
-                AND: [
-                  { name_contains: 'C' },
-                  { OR: [{ name_contains: 'z' }] },
-                ],
+                AND: [{ name_contains: 'C' }, { OR: [{ name_contains: 'z' }] }],
               },
             ],
           },
@@ -759,10 +756,7 @@ const deepAndOrFilterTests = [
     where: {
       AND: [
         {
-          OR: [
-            { AND: [] },
-            { AND: [{ name: 'Nobody' }] },
-          ],
+          OR: [{ AND: [] }, { AND: [{ name: 'Nobody' }] }],
         },
         {
           OR: [{ name: 'Alice' }, { name: 'David' }],
@@ -780,16 +774,10 @@ const divergenceAndOrFilterTests = [
     where: {
       OR: [
         {
-          AND: [
-            { company: { name: 'Thinkmill' } },
-            { posts_some: { content: 'World' } },
-          ],
+          AND: [{ company: { name: 'Thinkmill' } }, { posts_some: { content: 'World' } }],
         },
         {
-          AND: [
-            { company: { name: 'Cete' } },
-            { posts_some: { content: 'Hello' } },
-          ],
+          AND: [{ company: { name: 'Cete' } }, { posts_some: { content: 'Hello' } }],
         },
       ],
     },
@@ -857,10 +845,7 @@ const divergenceAndOrFilterTests = [
     id: 'or_every_or_none_same_relationship',
     case: 'OR with posts_every and posts_none on same relationship',
     where: {
-      OR: [
-        { posts_every: { content: 'Hello' } },
-        { posts_none: { content: 'Hello' } },
-      ],
+      OR: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'Hello' } }],
     },
     expect_ids: ['Bob', 'Charlie', 'David', 'Eve60'],
   },
@@ -868,10 +853,7 @@ const divergenceAndOrFilterTests = [
     id: 'or_every_and_none_same_relationship',
     case: 'OR with posts_every and posts_none on same relationship',
     where: {
-      AND: [
-        { posts_every: { content: 'Hello' } },
-        { posts_none: { content: 'Hello' } },
-      ],
+      AND: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'Hello' } }],
     },
     expect_ids: ['David'],
   },
@@ -909,10 +891,7 @@ const divergenceAndOrFilterTests = [
     id: 'or_company_empty_and_or_null_covers_all',
     case: 'company empty AND plus company_is_null should cover all users',
     where: {
-      OR: [
-        { company: { AND: [] } },
-        { company_is_null: true },
-      ],
+      OR: [{ company: { AND: [] } }, { company_is_null: true }],
     },
     expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
@@ -921,10 +900,7 @@ const divergenceAndOrFilterTests = [
     id: 'and_company_null_and_empty_and_contradiction',
     case: 'company_is_null and company empty AND should be contradictory',
     where: {
-      AND: [
-        { company_is_null: true },
-        { company: { AND: [] } },
-      ],
+      AND: [{ company_is_null: true }, { company: { AND: [] } }],
     },
     expect_ids: [],
   },
@@ -954,10 +930,7 @@ const divergenceAndOrFilterTests = [
         },
         {
           age_gt: 25,
-          OR: [
-            { email_contains: 'other' },
-            { company: { name: 'Thinkmill' } },
-          ],
+          OR: [{ email_contains: 'other' }, { company: { name: 'Thinkmill' } }],
         },
       ],
     },
@@ -970,16 +943,10 @@ const divergenceAndOrFilterTests = [
     where: {
       OR: [
         {
-          AND: [
-            { posts_some: { content: 'Hello' } },
-            { age: 20 },
-          ],
+          AND: [{ posts_some: { content: 'Hello' } }, { age: 20 }],
         },
         {
-          AND: [
-            { posts_some: { content: 'Bye' } },
-            { age: 40 },
-          ],
+          AND: [{ posts_some: { content: 'Bye' } }, { age: 40 }],
         },
       ],
     },
@@ -990,10 +957,7 @@ const divergenceAndOrFilterTests = [
     id: 'or_scalar_branch_with_multi_row_relationship_branch_no_duplicates',
     case: 'OR with scalar branch and multi-row relationship branch should not duplicate users',
     where: {
-      OR: [
-        { name: 'Alice' },
-        { posts_some: { content_contains: 'o' } },
-      ],
+      OR: [{ name: 'Alice' }, { posts_some: { content_contains: 'o' } }],
     },
     expect_ids: ['Alice', 'Bob', 'Eve60'],
   },
@@ -1006,10 +970,7 @@ const divergenceAndOrFilterTests = [
         { name: 'Alice' },
         {
           posts_some: {
-            OR: [
-              { content_contains: 'o' },
-              { content_contains: 'l' },
-            ],
+            OR: [{ content_contains: 'o' }, { content_contains: 'l' }],
           },
         },
       ],
@@ -1051,16 +1012,10 @@ const divergenceAndOrFilterTests = [
       posts_none: {
         OR: [
           {
-            AND: [
-              { content_contains: 'H' },
-              { content_contains: 'e' },
-            ],
+            AND: [{ content_contains: 'H' }, { content_contains: 'e' }],
           },
           {
-            AND: [
-              { content: 'Bye' },
-              { OR: [{ content_contains: 'y' }] },
-            ],
+            AND: [{ content: 'Bye' }, { OR: [{ content_contains: 'y' }] }],
           },
         ],
       },
@@ -1075,16 +1030,10 @@ const divergenceAndOrFilterTests = [
       posts_some: {
         OR: [
           {
-            AND: [
-              { content: 'Hello' },
-              { content: 'World' },
-            ],
+            AND: [{ content: 'Hello' }, { content: 'World' }],
           },
           {
-            AND: [
-              { content: 'Bye' },
-              { content_contains: 'y' },
-            ],
+            AND: [{ content: 'Bye' }, { content_contains: 'y' }],
           },
         ],
       },
@@ -1098,16 +1047,10 @@ const divergenceAndOrFilterTests = [
     where: {
       OR: [
         {
-          AND: [
-            { company: { name: 'Thinkmill' } },
-            { company: { name: 'Cete' } },
-          ],
+          AND: [{ company: { name: 'Thinkmill' } }, { company: { name: 'Cete' } }],
         },
         {
-          AND: [
-            { posts_some: { content: 'Bye' } },
-            { name_contains: 'a' },
-          ],
+          AND: [{ posts_some: { content: 'Bye' } }, { name_contains: 'a' }],
         },
       ],
     },

--- a/tests/api-tests/queries/complex-filters.test.js
+++ b/tests/api-tests/queries/complex-filters.test.js
@@ -2,31 +2,61 @@ const { multiAdapterRunners, setupServer } = require('@open-keystone/test-utils'
 const { Text, Integer, Relationship } = require('@open-keystone/fields');
 const { createItem } = require('@open-keystone/server-side-graphql-client');
 
-const setupKeystone = adapterName =>
-  setupServer({
-    adapterName,
-    createLists: keystone => {
-      keystone.createList('User', {
-        fields: {
-          name: { type: Text },
-          email: { type: Text },
-          age: { type: Integer },
-          company: { type: Relationship, ref: 'Company' },
-          posts: { type: Relationship, ref: 'Post', many: true },
-        },
-      });
-      keystone.createList('Company', {
-        fields: {
-          name: { type: Text },
-        },
-      });
-      keystone.createList('Post', {
-        fields: {
-          content: { type: Text },
-        },
-      });
+const createFixture = async keystone => {
+  const companies = {};
+  companies.c1 = await createItem({ keystone, listKey: 'Company', item: { name: 'Thinkmill' } });
+  companies.c2 = await createItem({ keystone, listKey: 'Company', item: { name: 'Cete' } });
+
+  const posts = {};
+  posts.p1 = await createItem({ keystone, listKey: 'Post', item: { content: 'Hello' } });
+  posts.p2 = await createItem({ keystone, listKey: 'Post', item: { content: 'World' } });
+  posts.p3 = await createItem({ keystone, listKey: 'Post', item: { content: 'Bye' } });
+
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'Alice',
+      age: 20,
+      email: 'alice@example.com',
+      company: { connect: { id: companies.c1.id } },
+      posts: { connect: [{ id: posts.p1.id }, { id: posts.p2.id }] },
     },
   });
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'Bob',
+      age: 30,
+      email: 'bob@example.com',
+      company: { connect: { id: companies.c1.id } },
+      posts: { connect: [{ id: posts.p1.id }] },
+    },
+  });
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'Charlie',
+      age: 40,
+      email: 'charlie@other.com',
+      company: { connect: { id: companies.c2.id } },
+      posts: { connect: [{ id: posts.p3.id }] },
+    },
+  });
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'David',
+      age: 50,
+      email: 'david@example.com',
+      company: null,
+      posts: { connect: [] },
+    },
+  });
+};
 
 const complexFilterTests = [
   {
@@ -90,12 +120,6 @@ const complexFilterTests = [
     expect_ids: ['Alice', 'Bob'],
   },
   {
-    id: 'and_with_multiple_posts_some',
-    case: 'AND with multiple posts_some (conditions on POTENTIALLY DIFFERENT posts)',
-    where: { AND: [{ posts_some: { content: 'Hello' } }, { posts_some: { content: 'World' } }] },
-    expect_ids: ['Alice'],
-  },
-  {
     id: 'posts_every_with_or',
     case: 'Relationship posts_every with OR',
     where: { posts_every: { OR: [{ content: 'Hello' }, { content: 'World' }] } },
@@ -113,12 +137,9 @@ const complexFilterTests = [
     where: {
       AND: [
         {
-          OR: [
-            { AND: [{ name: 'Alice' }] },
-            { AND: [{ name: 'Bob' }, { age: 30 }] }
-          ]
-        }
-      ]
+          OR: [{ AND: [{ name: 'Alice' }] }, { AND: [{ name: 'Bob' }, { age: 30 }] }],
+        },
+      ],
     },
     expect_ids: ['Alice', 'Bob'],
   },
@@ -145,110 +166,464 @@ const complexFilterTests = [
     case: 'OR with mixed nested AND and scalar fields',
     where: { OR: [{ AND: [{ name: 'Alice' }, { age: 30 }] }, { name: 'Bob' }] },
     expect_ids: ['Bob'],
-  }
+  },
+  {
+    id: 'and_multiple_conditions_same_field',
+    case: 'AND with multiple conditions on the same field',
+    where: { AND: [{ age_gt: 25 }, { age_lt: 45 }] },
+    expect_ids: ['Bob', 'Charlie'],
+  },
+  {
+    id: 'or_nested_inside_or',
+    case: 'OR nested inside OR',
+    where: { OR: [{ name: 'Alice' }, { OR: [{ name: 'Bob' }, { name: 'Charlie' }] }] },
+    expect_ids: ['Alice', 'Bob', 'Charlie'],
+  },
+  {
+    id: 'and_with_empty_object',
+    case: 'AND with empty object',
+    where: { AND: [{}] },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'or_with_empty_object',
+    case: 'OR with empty object',
+    where: { OR: [{}] },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'or_with_null_relationship',
+    case: 'OR with null relationship filter',
+    where: { OR: [{ company_is_null: true }, { name: 'Alice' }] },
+    expect_ids: ['Alice', 'David'],
+  },
+];
+
+const extraComplexFilterTests = [
+  {
+    id: 'root_and_or_scalar_same_level',
+    case: 'Scalar, AND and OR on the same root level should be implicit AND',
+    where: {
+      name_contains: 'i',
+      AND: [{ age_gt: 25 }],
+      OR: [{ company_is_null: true }, { email_contains: 'other' }],
+    },
+    expect_ids: ['Charlie', 'David'],
+  },
+  {
+    id: 'root_and_or_scalar_same_level2',
+    case: 'Scalar, AND and OR on the same root level should all be combined as implicit AND',
+    where: {
+      name_contains: 'i',
+      AND: [{ age_gt: 25 }],
+      OR: [{ company_is_null: true }],
+    },
+    expect_ids: ['David'],
+  },
+  {
+    id: 'root_and_empty_with_scalar',
+    case: 'Empty AND on root should be neutral',
+    where: { name_contains: 'i', AND: [] },
+    expect_ids: ['Alice', 'Charlie', 'David'],
+  },
+  {
+    id: 'root_or_empty_with_scalar',
+    case: 'Empty OR on root should make the whole filter false',
+    where: { name_contains: 'i', OR: [] },
+    expect_ids: [],
+  },
+  {
+    id: 'and_with_nested_empty_or',
+    case: 'AND containing empty OR should match nothing',
+    where: { AND: [{ OR: [] }] },
+    expect_ids: [],
+  },
+  {
+    id: 'or_with_nested_empty_and',
+    case: 'OR containing empty AND should match everything',
+    where: { OR: [{ AND: [] }] },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'implicit_and_same_field_multiple_number_ops',
+    case: 'Multiple operators for same scalar field should be implicit AND',
+    where: { age_gt: 20, age_lt: 50 },
+    expect_ids: ['Bob', 'Charlie'],
+  },
+  {
+    id: 'or_with_implicit_and_same_field_multiple_number_ops',
+    case: 'Implicit AND inside OR branch with multiple operators on same field',
+    where: { OR: [{ age_gt: 20, age_lt: 50 }, { company_is_null: true }] },
+    expect_ids: ['Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'or_with_company_null_or_company_name',
+    case: 'OR with null relationship branch and nested relationship branch',
+    where: { OR: [{ company_is_null: true }, { company: { name: 'Cete' } }] },
+    expect_ids: ['Charlie', 'David'],
+  },
+  {
+    id: 'company_nested_or',
+    case: 'Nested OR inside to-one relationship filter',
+    where: { company: { OR: [{ name: 'Thinkmill' }, { name: 'Cete' }] } },
+    expect_ids: ['Alice', 'Bob', 'Charlie'],
+  },
+  {
+    id: 'company_scalar_and_or_same_level',
+    case: 'Scalar and OR on same level inside to-one relationship should be implicit AND',
+    where: { company: { name: 'Thinkmill', OR: [{ name: 'Cete' }] } },
+    expect_ids: [],
+  },
+  {
+    id: 'posts_some_same_related_item_impossible',
+    case: 'posts_some with AND should require one same post to satisfy all conditions',
+    where: { posts_some: { AND: [{ content: 'Hello' }, { content: 'World' }] } },
+    expect_ids: [],
+  },
+  {
+    id: 'posts_some_different_related_items_via_multiple_some',
+    case: 'Multiple posts_some filters may match different posts',
+    where: {
+      AND: [{ posts_some: { content: 'Hello' } }, { posts_some: { content: 'World' } }],
+    },
+    expect_ids: ['Alice'],
+  },
+  {
+    id: 'posts_some_or_same_related_item',
+    case: 'posts_some with OR should match one related post satisfying any branch',
+    where: { posts_some: { OR: [{ content: 'World' }, { content: 'Bye' }] } },
+    expect_ids: ['Alice', 'Charlie'],
+  },
+  {
+    id: 'posts_none_hello',
+    case: 'posts_none should match users with no matching posts, including users with no posts',
+    where: { posts_none: { content: 'Hello' } },
+    expect_ids: ['Charlie', 'David'],
+  },
+  {
+    id: 'posts_every_hello_vacuous_empty',
+    case: 'posts_every should be true for empty relationship',
+    where: { posts_every: { content: 'Hello' } },
+    expect_ids: ['Bob', 'David'],
+  },
+  {
+    id: 'posts_every_plus_some_requires_non_empty',
+    case: 'posts_every + posts_some should require non-empty relationship',
+    where: {
+      AND: [{ posts_every: { content: 'Hello' } }, { posts_some: { content: 'Hello' } }],
+    },
+    expect_ids: ['Bob'],
+  },
+  {
+    id: 'or_relationship_branches_should_not_duplicate_user',
+    case: 'OR branches should not duplicate user if both branches match',
+    where: {
+      OR: [{ posts_some: { content: 'Hello' } }, { posts_some: { content: 'World' } }],
+    },
+    expect_ids: ['Alice', 'Bob'],
+  },
+  {
+    id: 'or_branch_scalar_and_relationship_implicit_and',
+    case: 'Scalar and relationship inside OR branch should be implicit AND',
+    where: {
+      OR: [{ name: 'Alice', posts_some: { content: 'Bye' } }, { name: 'Bob' }],
+    },
+    expect_ids: ['Bob'],
+  },
+];
+
+const moreAndOrFilterTests = [
+  {
+    id: 'and_of_two_or_groups',
+    case: 'AND of two OR groups should preserve grouping',
+    where: {
+      AND: [
+        { OR: [{ name: 'Alice' }, { name: 'Bob' }, { name: 'Charlie' }] },
+        { OR: [{ age: 20 }, { age: 40 }] },
+      ],
+    },
+    expect_ids: ['Alice', 'Charlie'],
+  },
+  {
+    id: 'or_of_two_and_groups_negative_branches',
+    case: 'OR of AND groups should not leak partially matched branches',
+    where: {
+      OR: [
+        { AND: [{ name: 'Alice' }, { age: 30 }] },
+        { AND: [{ name: 'Bob' }, { age: 20 }] },
+        { AND: [{ name: 'Charlie' }, { age: 40 }] },
+      ],
+    },
+    expect_ids: ['Charlie'],
+  },
+  {
+    id: 'and_nested_inside_and',
+    case: 'Nested AND inside AND should be equivalent to flattened AND',
+    where: {
+      AND: [
+        { name_contains: 'i' },
+        { AND: [{ age_gt: 25 }, { age_lt: 50 }] },
+      ],
+    },
+    expect_ids: ['Charlie'],
+  },
+  {
+    id: 'or_inside_and_branch_with_scalar_same_level',
+    case: 'OR inside AND branch with scalar on same level should be implicit AND',
+    where: {
+      AND: [
+        {
+          name_contains: 'i',
+          OR: [{ age: 20 }, { age: 50 }],
+        },
+      ],
+    },
+    expect_ids: ['Alice', 'David'],
+  },
+  {
+    id: 'and_inside_or_branch_with_scalar_same_level',
+    case: 'AND inside OR branch with scalar on same level should be implicit AND',
+    where: {
+      OR: [
+        {
+          name_contains: 'i',
+          AND: [{ age_gt: 25 }],
+        },
+        { name: 'Bob' },
+      ],
+    },
+    expect_ids: ['Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'and_with_empty_object_and_scalar',
+    case: 'Empty object inside AND should be neutral when mixed with real condition',
+    where: {
+      AND: [{}, { name: 'Alice' }],
+    },
+    expect_ids: ['Alice'],
+  },
+  {
+    id: 'or_with_empty_object_and_scalar',
+    case: 'Empty object inside OR should make OR match everything',
+    where: {
+      OR: [{}, { name: 'Alice' }],
+    },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'and_with_empty_or_and_scalar',
+    case: 'Empty OR inside AND should make whole AND false',
+    where: {
+      AND: [{ OR: [] }, { name: 'Alice' }],
+    },
+    expect_ids: [],
+  },
+  {
+    id: 'or_with_empty_and_and_false_scalar',
+    case: 'Empty AND inside OR should make whole OR true',
+    where: {
+      OR: [{ AND: [] }, { name: 'Nobody' }],
+    },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'posts_some_scalar_and_or_same_level_impossible',
+    case: 'posts_some with scalar and OR on same related item should not match different posts',
+    where: {
+      posts_some: {
+        content_contains: 'H',
+        OR: [{ content: 'World' }],
+      },
+    },
+    expect_ids: [],
+  },
+  {
+    id: 'posts_some_scalar_and_or_same_level_positive',
+    case: 'posts_some with scalar and OR on same related item should match same post',
+    where: {
+      posts_some: {
+        content_contains: 'H',
+        OR: [{ content_contains: 'e' }, { content: 'World' }],
+      },
+    },
+    expect_ids: ['Alice', 'Bob'],
+  },
+  {
+    id: 'posts_none_with_or',
+    case: 'posts_none with OR should exclude users having any post matching any OR branch',
+    where: {
+      posts_none: {
+        OR: [{ content: 'Hello' }, { content: 'World' }],
+      },
+    },
+    expect_ids: ['Charlie', 'David'],
+  },
+  {
+    id: 'posts_none_with_and_impossible',
+    case: 'posts_none with impossible AND should match everyone',
+    where: {
+      posts_none: {
+        AND: [{ content: 'Hello' }, { content: 'World' }],
+      },
+    },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+  {
+    id: 'posts_every_with_and',
+    case: 'posts_every with AND should require every related post to satisfy both conditions',
+    where: {
+      posts_every: {
+        AND: [{ content_contains: 'l' }, { content_contains: 'o' }],
+      },
+    },
+    expect_ids: ['Alice', 'Bob', 'David'],
+  },
+  {
+    id: 'posts_every_with_empty_or',
+    case: 'posts_every with empty OR should only match users with no posts',
+    where: {
+      posts_every: {
+        OR: [],
+      },
+    },
+    expect_ids: ['David'],
+  },
+
+  {
+    id: 'posts_some_with_empty_and',
+    case: 'posts_some with empty AND should match users having at least one post',
+    where: {
+      posts_some: {
+        AND: [],
+      },
+    },
+    expect_ids: ['Alice', 'Bob', 'Charlie'],
+  },
+
+  {
+    id: 'posts_some_with_empty_or',
+    case: 'posts_some with empty OR should match nobody',
+    where: {
+      posts_some: {
+        OR: [],
+      },
+    },
+    expect_ids: [],
+  },
 ];
 
 const invalidFilterTests = [
   {
     id: 'unknown_filter_field',
+    case: 'Unknown filter field',
     where: { age_between: [20, 30] },
+    expected_error:
+      'Variable "$where" got invalid value { age_between: [20, 30] }; Field "age_between" is not defined by type "UserWhereInput".',
   },
   {
     id: 'wrong_scalar_type',
+    case: 'Wrong scalar type',
     where: { age_gt: '25' },
+    expected_error:
+      'Variable "$where" got invalid value "25" at "where.age_gt"; Int cannot represent non-integer value: "25"',
   },
   {
-    id: 'wrong_and_shape',
-    where: { AND: { age: 20 } },
+    id: 'wrong_and_type',
+    case: 'Wrong AND type',
+    where: { AND: 123 },
+    expected_error:
+      'Variable "$where" got invalid value 123 at "where.AND"; Expected type "UserWhereInput" to be an object.',
   },
   {
     id: 'null_inside_and_array',
+    case: 'Null inside AND array',
     where: { AND: [null] },
+    expected_error:
+      'Variable "$where" got invalid value null at "where.AND[0]"; Expected non-nullable type "UserWhereInput!" not to be null.',
   },
   {
     id: 'unknown_logical_operator',
+    case: 'Unknown logical operator',
     where: { NOT: [{ name: 'Alice' }] },
+    expected_error:
+      'Variable "$where" got invalid value { NOT: [[Object]] }; Field "NOT" is not defined by type "UserWhereInput".',
+  },
+  {
+    id: 'wrong_or_type',
+    case: 'Wrong OR type',
+    where: { OR: 123 },
+    expected_error:
+      'Variable "$where" got invalid value 123 at "where.OR"; Expected type "UserWhereInput" to be an object.',
+  },
+  {
+    id: 'null_inside_or_array',
+    case: 'Null inside OR array',
+    where: { OR: [null] },
+    expected_error:
+      'Variable "$where" got invalid value null at "where.OR[0]"; Expected non-nullable type "UserWhereInput!" not to be null.',
   },
 ];
 
-const createFixture = async keystone => {
-  const companies = {};
-  companies.c1 = await createItem({ keystone, listKey: 'Company', item: { name: 'Thinkmill' } });
-  companies.c2 = await createItem({ keystone, listKey: 'Company', item: { name: 'Cete' } });
-
-  const posts = {};
-  posts.p1 = await createItem({ keystone, listKey: 'Post', item: { content: 'Hello' } });
-  posts.p2 = await createItem({ keystone, listKey: 'Post', item: { content: 'World' } });
-  posts.p3 = await createItem({ keystone, listKey: 'Post', item: { content: 'Bye' } });
-
-  await createItem({
-    keystone,
-    listKey: 'User',
-    item: {
-      name: 'Alice',
-      age: 20,
-      email: 'alice@example.com',
-      company: { connect: { id: companies.c1.id } },
-      posts: { connect: [{ id: posts.p1.id }, { id: posts.p2.id }] },
+const setupKeystone = adapterName =>
+  setupServer({
+    adapterName,
+    createLists: keystone => {
+      keystone.createList('User', {
+        fields: {
+          name: { type: Text },
+          email: { type: Text },
+          age: { type: Integer },
+          company: { type: Relationship, ref: 'Company' },
+          posts: { type: Relationship, ref: 'Post', many: true },
+        },
+      });
+      keystone.createList('Company', {
+        fields: {
+          name: { type: Text },
+        },
+      });
+      keystone.createList('Post', {
+        fields: {
+          content: { type: Text },
+        },
+      });
     },
   });
-  await createItem({
-    keystone,
-    listKey: 'User',
-    item: {
-      name: 'Bob',
-      age: 30,
-      email: 'bob@example.com',
-      company: { connect: { id: companies.c1.id } },
-      posts: { connect: [{ id: posts.p1.id }] },
-    },
-  });
-  await createItem({
-    keystone,
-    listKey: 'User',
-    item: {
-      name: 'Charlie',
-      age: 40,
-      email: 'charlie@other.com',
-      company: { connect: { id: companies.c2.id } },
-      posts: { connect: [{ id: posts.p3.id }] },
-    },
-  });
-  await createItem({
-    keystone,
-    listKey: 'User',
-    item: {
-      name: 'David',
-      age: 50,
-      email: 'david@example.com',
-      company: null,
-      posts: { connect: [] },
-    },
-  });
-};
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
     describe('Complex AND/OR filters', () => {
-      const tests = [
-        ...complexFilterTests,
-        // ...invalidFilterTests,
-      ];
-      tests.forEach(({ id, case: title, where, expect_ids, ...expected }) => {
+      const cases = [...complexFilterTests, ...extraComplexFilterTests, ...moreAndOrFilterTests];
+      cases.forEach(({ id, case: title, where, expect_ids, ...expected }) => {
         test(
-          `${id} : ${title}`,
+          `Valid: ${id} : ${title}`,
           runner(setupKeystone, async ({ keystone }) => {
             await createFixture(keystone);
             const { data, errors } = await keystone.executeGraphQL({
               query: `query($where: UserWhereInput) { allUsers(where: $where) { name } }`,
               variables: { where },
             });
-            expect(errors).toBe(undefined);
+            expect(errors).toBeUndefined();
             const ids = data.allUsers.map(u => u.name).sort();
-            const result = (
-              adapterName in expected ? expected[adapterName] : expect_ids
-            ).sort();
+            const result = (adapterName in expected ? expected[adapterName] : expect_ids).sort();
             expect(ids).toEqual(result);
+          })
+        );
+      });
+
+      invalidFilterTests.forEach(({ id, case: title, where, expected_error, ...expected }) => {
+        test(
+          `Invalid: ${id} : ${title}`,
+          runner(setupKeystone, async ({ keystone }) => {
+            await createFixture(keystone);
+            const { data, errors } = await keystone.executeGraphQL({
+              query: `query($where: UserWhereInput) { allUsers(where: $where) { name } }`,
+              variables: { where },
+            });
+            expect(errors).not.toBe(undefined);
+            const expectedMessage = expected[adapterName] || expected_error;
+            expect(errors[0].message).toEqual(expect.stringContaining(expectedMessage));
+            expect(data).toBeUndefined();
           })
         );
       });

--- a/tests/api-tests/queries/complex-filters.test.js
+++ b/tests/api-tests/queries/complex-filters.test.js
@@ -56,6 +56,17 @@ const createFixture = async keystone => {
       posts: { connect: [] },
     },
   });
+  await createItem({
+    keystone,
+    listKey: 'User',
+    item: {
+      name: 'Eve60',
+      age: 60,
+      email: 'eve@example.com',
+      company: { connect: { id: companies.c2.id } },
+      posts: { connect: [{ id: posts.p2.id }] },
+    },
+  });
 };
 
 const complexFilterTests = [
@@ -97,13 +108,13 @@ const complexFilterTests = [
   },
   {
     id: 'empty_and',
-    case: 'Empty AND array',
+    case: 'Empty AND array means There are no conditions that need to be violated',
     where: { AND: [] },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
   {
     id: 'empty_or',
-    case: 'Empty OR array',
+    case: 'Empty OR array meands None of the alternatives can be applied here',
     where: { OR: [] },
     expect_ids: [],
   },
@@ -123,13 +134,13 @@ const complexFilterTests = [
     id: 'posts_every_with_or',
     case: 'Relationship posts_every with OR',
     where: { posts_every: { OR: [{ content: 'Hello' }, { content: 'World' }] } },
-    expect_ids: ['Alice', 'Bob', 'David'],
+    expect_ids: ['Alice', 'Bob', 'David', 'Eve60'],
   },
   {
     id: 'or_with_same_field_repeated',
     case: 'OR with same field repeated with different conditions',
     where: { OR: [{ age_lt: 25 }, { age_gt: 45 }] },
-    expect_ids: ['Alice', 'David'],
+    expect_ids: ['Alice', 'David', 'Eve60'],
   },
   {
     id: 'deeply_nested_and_or',
@@ -183,13 +194,13 @@ const complexFilterTests = [
     id: 'and_with_empty_object',
     case: 'AND with empty object',
     where: { AND: [{}] },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
   {
     id: 'or_with_empty_object',
     case: 'OR with empty object',
     where: { OR: [{}] },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
   {
     id: 'or_with_null_relationship',
@@ -242,7 +253,7 @@ const extraComplexFilterTests = [
     id: 'or_with_nested_empty_and',
     case: 'OR containing empty AND should match everything',
     where: { OR: [{ AND: [] }] },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
   {
     id: 'implicit_and_same_field_multiple_number_ops',
@@ -260,13 +271,13 @@ const extraComplexFilterTests = [
     id: 'or_with_company_null_or_company_name',
     case: 'OR with null relationship branch and nested relationship branch',
     where: { OR: [{ company_is_null: true }, { company: { name: 'Cete' } }] },
-    expect_ids: ['Charlie', 'David'],
+    expect_ids: ['Charlie', 'David', 'Eve60'],
   },
   {
     id: 'company_nested_or',
     case: 'Nested OR inside to-one relationship filter',
     where: { company: { OR: [{ name: 'Thinkmill' }, { name: 'Cete' }] } },
-    expect_ids: ['Alice', 'Bob', 'Charlie'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'Eve60'],
   },
   {
     id: 'company_scalar_and_or_same_level',
@@ -292,13 +303,13 @@ const extraComplexFilterTests = [
     id: 'posts_some_or_same_related_item',
     case: 'posts_some with OR should match one related post satisfying any branch',
     where: { posts_some: { OR: [{ content: 'World' }, { content: 'Bye' }] } },
-    expect_ids: ['Alice', 'Charlie'],
+    expect_ids: ['Alice', 'Charlie', 'Eve60'],
   },
   {
     id: 'posts_none_hello',
     case: 'posts_none should match users with no matching posts, including users with no posts',
     where: { posts_none: { content: 'Hello' } },
-    expect_ids: ['Charlie', 'David'],
+    expect_ids: ['Charlie', 'David', 'Eve60'],
   },
   {
     id: 'posts_every_hello_vacuous_empty',
@@ -320,7 +331,7 @@ const extraComplexFilterTests = [
     where: {
       OR: [{ posts_some: { content: 'Hello' } }, { posts_some: { content: 'World' } }],
     },
-    expect_ids: ['Alice', 'Bob'],
+    expect_ids: ['Alice', 'Bob', 'Eve60'],
   },
   {
     id: 'or_branch_scalar_and_relationship_implicit_and',
@@ -405,7 +416,7 @@ const moreAndOrFilterTests = [
     where: {
       OR: [{}, { name: 'Alice' }],
     },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
   {
     id: 'and_with_empty_or_and_scalar',
@@ -421,7 +432,7 @@ const moreAndOrFilterTests = [
     where: {
       OR: [{ AND: [] }, { name: 'Nobody' }],
     },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
   {
     id: 'posts_some_scalar_and_or_same_level_impossible',
@@ -463,7 +474,7 @@ const moreAndOrFilterTests = [
         AND: [{ content: 'Hello' }, { content: 'World' }],
       },
     },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
   {
     id: 'posts_every_with_and',
@@ -473,7 +484,7 @@ const moreAndOrFilterTests = [
         AND: [{ content_contains: 'l' }, { content_contains: 'o' }],
       },
     },
-    expect_ids: ['Alice', 'Bob', 'David'],
+    expect_ids: ['Alice', 'Bob', 'David', 'Eve60'],
   },
   {
     id: 'posts_every_with_empty_or',
@@ -494,7 +505,7 @@ const moreAndOrFilterTests = [
         AND: [],
       },
     },
-    expect_ids: ['Alice', 'Bob', 'Charlie'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'Eve60'],
   },
 
   {
@@ -714,7 +725,7 @@ const deepAndOrFilterTests = [
         ],
       },
     },
-    expect_ids: ['Alice', 'Bob', 'David'],
+    expect_ids: ['Alice', 'Bob', 'David', 'Eve60'],
   },
 
   {
@@ -839,7 +850,7 @@ const divergenceAndOrFilterTests = [
         { posts_none: { content: 'Bye' } },
       ],
     },
-    expect_ids: ['Alice', 'Bob'],
+    expect_ids: ['Alice', 'Bob', 'Eve60'],
   },
 
   {
@@ -851,7 +862,7 @@ const divergenceAndOrFilterTests = [
         { posts_none: { content: 'Hello' } },
       ],
     },
-    expect_ids: ['Bob', 'Charlie', 'David'],
+    expect_ids: ['Bob', 'Charlie', 'David', 'Eve60'],
   },
   {
     id: 'or_every_and_none_same_relationship',
@@ -882,7 +893,7 @@ const divergenceAndOrFilterTests = [
     where: {
       company: { AND: [] },
     },
-    expect_ids: ['Alice', 'Bob', 'Charlie'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'Eve60'],
   },
 
   {
@@ -903,7 +914,7 @@ const divergenceAndOrFilterTests = [
         { company_is_null: true },
       ],
     },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
 
   {
@@ -984,7 +995,7 @@ const divergenceAndOrFilterTests = [
         { posts_some: { content_contains: 'o' } },
       ],
     },
-    expect_ids: ['Alice', 'Bob'],
+    expect_ids: ['Alice', 'Bob', 'Eve60'],
   },
 
   {
@@ -1017,12 +1028,25 @@ const divergenceAndOrFilterTests = [
         ],
       },
     },
-    expect_ids: ['Alice', 'Bob', 'David'],
+    expect_ids: ['Alice', 'Bob', 'David', 'Eve60'],
+  },
+  {
+    id: 'posts_every_deep_and_of_or_groups2',
+    case: 'posts_every with AND of OR groups should match only World post',
+    where: {
+      posts_every: {
+        AND: [
+          { OR: [{ content: 'Hello' }, { content: 'World' }] },
+          { OR: [{ content_contains: 'W' }] },
+        ],
+      },
+    },
+    expect_ids: ['David', 'Eve60'],
   },
 
   {
     id: 'posts_none_deep_or_of_and_groups',
-    case: 'posts_none with OR of AND groups should apply anti-join correctly',
+    case: 'There are no posts matching either the Hello-like or Bye-like criteria',
     where: {
       posts_none: {
         OR: [
@@ -1041,7 +1065,7 @@ const divergenceAndOrFilterTests = [
         ],
       },
     },
-    expect_ids: ['David'],
+    expect_ids: ['David', 'Eve60'],
   },
 
   {
@@ -1148,10 +1172,7 @@ const quantifierAndOrDivergenceTests = [
     id: 'and_every_hello_none_world',
     case: 'AND with posts_every Hello and posts_none World',
     where: {
-      AND: [
-        { posts_every: { content: 'Hello' } },
-        { posts_none: { content: 'World' } },
-      ],
+      AND: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'World' } }],
     },
     expect_ids: ['Bob', 'David'],
   },
@@ -1160,10 +1181,7 @@ const quantifierAndOrDivergenceTests = [
     id: 'and_every_hello_every_world',
     case: 'AND with two contradictory posts_every filters should match only empty relationship',
     where: {
-      AND: [
-        { posts_every: { content: 'Hello' } },
-        { posts_every: { content: 'World' } },
-      ],
+      AND: [{ posts_every: { content: 'Hello' } }, { posts_every: { content: 'World' } }],
     },
     expect_ids: ['David'],
   },
@@ -1172,36 +1190,27 @@ const quantifierAndOrDivergenceTests = [
     id: 'or_every_hello_every_world',
     case: 'OR with two posts_every filters should preserve vacuous empty relationship',
     where: {
-      OR: [
-        { posts_every: { content: 'Hello' } },
-        { posts_every: { content: 'World' } },
-      ],
+      OR: [{ posts_every: { content: 'Hello' } }, { posts_every: { content: 'World' } }],
     },
-    expect_ids: ['Bob', 'David'],
+    expect_ids: ['Bob', 'David', 'Eve60'],
   },
 
   {
     id: 'and_none_hello_none_world',
     case: 'AND with two posts_none filters',
     where: {
-      AND: [
-        { posts_none: { content: 'Hello' } },
-        { posts_none: { content: 'World' } },
-      ],
+      AND: [{ posts_none: { content: 'Hello' } }, { posts_none: { content: 'World' } }],
     },
     expect_ids: ['Charlie', 'David'],
   },
 
   {
-    id: 'or_none_hello_none_world',
-    case: 'OR with two posts_none filters',
+    id: 'none_hello_or_none_world',
+    case: 'The user is missing either a Hello post or a World post',
     where: {
-      OR: [
-        { posts_none: { content: 'Hello' } },
-        { posts_none: { content: 'World' } },
-      ],
+      OR: [{ posts_none: { content: 'Hello' } }, { posts_none: { content: 'World' } }],
     },
-    expect_ids: ['Bob', 'Charlie', 'David'],
+    expect_ids: ['Bob', 'Charlie', 'David', 'Eve60'],
   },
 
   {
@@ -1217,7 +1226,7 @@ const quantifierAndOrDivergenceTests = [
         { posts_none: { content: 'Hello' } },
       ],
     },
-    expect_ids: ['David'],
+    expect_ids: ['David', 'Eve60'],
   },
 
   {
@@ -1249,7 +1258,7 @@ const quantifierAndOrDivergenceTests = [
         { posts_some: { content: 'World' } },
       ],
     },
-    expect_ids: ['Alice'],
+    expect_ids: ['Alice', 'Eve60'],
   },
 
   {
@@ -1305,17 +1314,14 @@ const quantifierAndOrDivergenceTests = [
         },
       ],
     },
-    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David', 'Eve60'],
   },
 
   {
     id: 'and_some_hello_none_world',
     case: 'posts_some Hello combined with posts_none World',
     where: {
-      AND: [
-        { posts_some: { content: 'Hello' } },
-        { posts_none: { content: 'World' } },
-      ],
+      AND: [{ posts_some: { content: 'Hello' } }, { posts_none: { content: 'World' } }],
     },
     expect_ids: ['Bob'],
   },
@@ -1324,12 +1330,9 @@ const quantifierAndOrDivergenceTests = [
     id: 'and_some_world_none_hello',
     case: 'posts_some World combined with posts_none Hello should not match Alice because she has Hello',
     where: {
-      AND: [
-        { posts_some: { content: 'World' } },
-        { posts_none: { content: 'Hello' } },
-      ],
+      AND: [{ posts_some: { content: 'World' } }, { posts_none: { content: 'Hello' } }],
     },
-    expect_ids: [],
+    expect_ids: ['Eve60'],
   },
 
   {
@@ -1345,7 +1348,7 @@ const quantifierAndOrDivergenceTests = [
         },
       ],
     },
-    expect_ids: ['Alice'],
+    expect_ids: ['Alice', 'Eve60'],
   },
 
   {
@@ -1368,12 +1371,9 @@ const quantifierAndOrDivergenceTests = [
     id: 'or_some_world_every_hello',
     case: 'OR with posts_some World and posts_every Hello',
     where: {
-      OR: [
-        { posts_some: { content: 'World' } },
-        { posts_every: { content: 'Hello' } },
-      ],
+      OR: [{ posts_some: { content: 'World' } }, { posts_every: { content: 'Hello' } }],
     },
-    expect_ids: ['Alice', 'Bob', 'David'],
+    expect_ids: ['Alice', 'Bob', 'David', 'Eve60'],
   },
 
   {
@@ -1382,10 +1382,7 @@ const quantifierAndOrDivergenceTests = [
     where: {
       AND: [
         {
-          OR: [
-            { posts_every: { content: 'Hello' } },
-            { posts_none: { content: 'Hello' } },
-          ],
+          OR: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'Hello' } }],
         },
         { posts_some: { content: 'Hello' } },
       ],
@@ -1399,15 +1396,25 @@ const quantifierAndOrDivergenceTests = [
     where: {
       AND: [
         {
-          OR: [
-            { posts_every: { content: 'Hello' } },
-            { posts_none: { content: 'Hello' } },
-          ],
+          OR: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'Hello' } }],
         },
         { posts_some: { content: 'World' } },
       ],
     },
-    expect_ids: [],
+    expect_ids: ['Eve60'],
+  },
+  {
+    id: 'and_or_every_none_hello_with_every_world',
+    case: 'OR every/none Hello combined with posts_every World should only match empty relationship',
+    where: {
+      AND: [
+        {
+          OR: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'Hello' } }],
+        },
+        { posts_every: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['David', 'Eve60'],
   },
 
   {
@@ -1416,15 +1423,12 @@ const quantifierAndOrDivergenceTests = [
     where: {
       AND: [
         {
-          OR: [
-            { posts_every: { content: 'Hello' } },
-            { posts_none: { content: 'Hello' } },
-          ],
+          OR: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'Hello' } }],
         },
         { posts_none: { content: 'Bye' } },
       ],
     },
-    expect_ids: ['Bob', 'David'],
+    expect_ids: ['Bob', 'David', 'Eve60'],
   },
 
   {
@@ -1433,16 +1437,10 @@ const quantifierAndOrDivergenceTests = [
     where: {
       OR: [
         {
-          AND: [
-            { posts_every: { content: 'Hello' } },
-            { posts_none: { content: 'World' } },
-          ],
+          AND: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'World' } }],
         },
         {
-          AND: [
-            { posts_every: { content: 'Bye' } },
-            { posts_none: { content: 'Hello' } },
-          ],
+          AND: [{ posts_every: { content: 'Bye' } }, { posts_none: { content: 'Hello' } }],
         },
       ],
     },
@@ -1455,16 +1453,10 @@ const quantifierAndOrDivergenceTests = [
     where: {
       AND: [
         {
-          OR: [
-            { posts_every: { content: 'Hello' } },
-            { posts_none: { content: 'World' } },
-          ],
+          OR: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'World' } }],
         },
         {
-          OR: [
-            { posts_every: { content: 'Bye' } },
-            { posts_none: { content: 'Hello' } },
-          ],
+          OR: [{ posts_every: { content: 'Bye' } }, { posts_none: { content: 'Hello' } }],
         },
       ],
     },
@@ -1477,16 +1469,10 @@ const quantifierAndOrDivergenceTests = [
     where: {
       OR: [
         {
-          AND: [
-            { posts_every: { content: 'Hello' } },
-            { posts_none: { content: 'Hello' } },
-          ],
+          AND: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'Hello' } }],
         },
         {
-          AND: [
-            { posts_every: { content: 'World' } },
-            { posts_none: { content: 'World' } },
-          ],
+          AND: [{ posts_every: { content: 'World' } }, { posts_none: { content: 'World' } }],
         },
       ],
     },
@@ -1520,16 +1506,10 @@ const quantifierAndOrDivergenceTests = [
     where: {
       OR: [
         {
-          AND: [
-            { name: 'Alice' },
-            { posts_every: { content: 'Hello' } },
-          ],
+          AND: [{ name: 'Alice' }, { posts_every: { content: 'Hello' } }],
         },
         {
-          AND: [
-            { name: 'Charlie' },
-            { posts_none: { content: 'Hello' } },
-          ],
+          AND: [{ name: 'Charlie' }, { posts_none: { content: 'Hello' } }],
         },
         {
           AND: [
@@ -1549,10 +1529,7 @@ const quantifierAndOrDivergenceTests = [
     where: {
       AND: [
         {
-          OR: [
-            { posts_every: { content: 'Hello' } },
-            { posts_none: { content: 'World' } },
-          ],
+          OR: [{ posts_every: { content: 'Hello' } }, { posts_none: { content: 'World' } }],
         },
         {
           OR: [{ name: 'Alice' }, { name: 'Bob' }],

--- a/tests/api-tests/queries/complex-filters.test.js
+++ b/tests/api-tests/queries/complex-filters.test.js
@@ -360,10 +360,7 @@ const moreAndOrFilterTests = [
     id: 'and_nested_inside_and',
     case: 'Nested AND inside AND should be equivalent to flattened AND',
     where: {
-      AND: [
-        { name_contains: 'i' },
-        { AND: [{ age_gt: 25 }, { age_lt: 50 }] },
-      ],
+      AND: [{ name_contains: 'i' }, { AND: [{ age_gt: 25 }, { age_lt: 50 }] }],
     },
     expect_ids: ['Charlie'],
   },
@@ -509,6 +506,16 @@ const moreAndOrFilterTests = [
       },
     },
     expect_ids: [],
+  },
+  {
+    id: 'posts_none_with_empty_and',
+    case: 'posts_none with empty AND should match users having no posts',
+    where: {
+      posts_none: {
+        AND: [],
+      },
+    },
+    expect_ids: ['David'],
   },
 ];
 

--- a/tests/api-tests/queries/complex-filters.test.js
+++ b/tests/api-tests/queries/complex-filters.test.js
@@ -1143,6 +1143,426 @@ const invalidFilterTests = [
   },
 ];
 
+const quantifierAndOrDivergenceTests = [
+  {
+    id: 'and_every_hello_none_world',
+    case: 'AND with posts_every Hello and posts_none World',
+    where: {
+      AND: [
+        { posts_every: { content: 'Hello' } },
+        { posts_none: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['Bob', 'David'],
+  },
+
+  {
+    id: 'and_every_hello_every_world',
+    case: 'AND with two contradictory posts_every filters should match only empty relationship',
+    where: {
+      AND: [
+        { posts_every: { content: 'Hello' } },
+        { posts_every: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['David'],
+  },
+
+  {
+    id: 'or_every_hello_every_world',
+    case: 'OR with two posts_every filters should preserve vacuous empty relationship',
+    where: {
+      OR: [
+        { posts_every: { content: 'Hello' } },
+        { posts_every: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['Bob', 'David'],
+  },
+
+  {
+    id: 'and_none_hello_none_world',
+    case: 'AND with two posts_none filters',
+    where: {
+      AND: [
+        { posts_none: { content: 'Hello' } },
+        { posts_none: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['Charlie', 'David'],
+  },
+
+  {
+    id: 'or_none_hello_none_world',
+    case: 'OR with two posts_none filters',
+    where: {
+      OR: [
+        { posts_none: { content: 'Hello' } },
+        { posts_none: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['Bob', 'Charlie', 'David'],
+  },
+
+  {
+    id: 'and_every_hello_or_world_none_hello',
+    case: 'posts_every OR group combined with posts_none Hello',
+    where: {
+      AND: [
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+        { posts_none: { content: 'Hello' } },
+      ],
+    },
+    expect_ids: ['David'],
+  },
+
+  {
+    id: 'and_every_hello_or_world_none_world',
+    case: 'posts_every OR group combined with posts_none World',
+    where: {
+      AND: [
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+        { posts_none: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['Bob', 'David'],
+  },
+
+  {
+    id: 'and_every_hello_or_world_some_world',
+    case: 'posts_every OR group combined with posts_some World should require non-empty matching item',
+    where: {
+      AND: [
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+        { posts_some: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['Alice'],
+  },
+
+  {
+    id: 'and_every_hello_or_world_some_hello',
+    case: 'posts_every OR group combined with posts_some Hello',
+    where: {
+      AND: [
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+        { posts_some: { content: 'Hello' } },
+      ],
+    },
+    expect_ids: ['Alice', 'Bob'],
+  },
+
+  {
+    id: 'and_every_or_group_none_same_or_group',
+    case: 'All posts are Hello/World AND no posts are Hello/World should match only empty relationship',
+    where: {
+      AND: [
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+        {
+          posts_none: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+      ],
+    },
+    expect_ids: ['David'],
+  },
+
+  {
+    id: 'or_every_or_group_none_same_or_group',
+    case: 'All posts are Hello/World OR no posts are Hello/World should cover all fixture users',
+    where: {
+      OR: [
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+        {
+          posts_none: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+      ],
+    },
+    expect_ids: ['Alice', 'Bob', 'Charlie', 'David'],
+  },
+
+  {
+    id: 'and_some_hello_none_world',
+    case: 'posts_some Hello combined with posts_none World',
+    where: {
+      AND: [
+        { posts_some: { content: 'Hello' } },
+        { posts_none: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['Bob'],
+  },
+
+  {
+    id: 'and_some_world_none_hello',
+    case: 'posts_some World combined with posts_none Hello should not match Alice because she has Hello',
+    where: {
+      AND: [
+        { posts_some: { content: 'World' } },
+        { posts_none: { content: 'Hello' } },
+      ],
+    },
+    expect_ids: [],
+  },
+
+  {
+    id: 'and_some_world_every_hello_or_world',
+    case: 'posts_some World plus posts_every Hello/World',
+    where: {
+      AND: [
+        { posts_some: { content: 'World' } },
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+      ],
+    },
+    expect_ids: ['Alice'],
+  },
+
+  {
+    id: 'and_some_bye_every_hello_or_bye',
+    case: 'posts_some Bye plus posts_every Hello/Bye',
+    where: {
+      AND: [
+        { posts_some: { content: 'Bye' } },
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'Bye' }],
+          },
+        },
+      ],
+    },
+    expect_ids: ['Charlie'],
+  },
+
+  {
+    id: 'or_some_world_every_hello',
+    case: 'OR with posts_some World and posts_every Hello',
+    where: {
+      OR: [
+        { posts_some: { content: 'World' } },
+        { posts_every: { content: 'Hello' } },
+      ],
+    },
+    expect_ids: ['Alice', 'Bob', 'David'],
+  },
+
+  {
+    id: 'and_or_every_none_hello_with_some_hello',
+    case: 'OR every/none Hello group combined with posts_some Hello should exclude empty relationship',
+    where: {
+      AND: [
+        {
+          OR: [
+            { posts_every: { content: 'Hello' } },
+            { posts_none: { content: 'Hello' } },
+          ],
+        },
+        { posts_some: { content: 'Hello' } },
+      ],
+    },
+    expect_ids: ['Bob'],
+  },
+
+  {
+    id: 'and_or_every_none_hello_with_some_world',
+    case: 'OR every/none Hello group combined with posts_some World should not leak Alice',
+    where: {
+      AND: [
+        {
+          OR: [
+            { posts_every: { content: 'Hello' } },
+            { posts_none: { content: 'Hello' } },
+          ],
+        },
+        { posts_some: { content: 'World' } },
+      ],
+    },
+    expect_ids: [],
+  },
+
+  {
+    id: 'and_or_every_none_hello_with_none_bye',
+    case: 'OR every/none Hello group combined with posts_none Bye',
+    where: {
+      AND: [
+        {
+          OR: [
+            { posts_every: { content: 'Hello' } },
+            { posts_none: { content: 'Hello' } },
+          ],
+        },
+        { posts_none: { content: 'Bye' } },
+      ],
+    },
+    expect_ids: ['Bob', 'David'],
+  },
+
+  {
+    id: 'or_of_and_every_none_different_predicates',
+    case: 'OR of AND groups with every/none on different predicates',
+    where: {
+      OR: [
+        {
+          AND: [
+            { posts_every: { content: 'Hello' } },
+            { posts_none: { content: 'World' } },
+          ],
+        },
+        {
+          AND: [
+            { posts_every: { content: 'Bye' } },
+            { posts_none: { content: 'Hello' } },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Bob', 'Charlie', 'David'],
+  },
+
+  {
+    id: 'and_of_or_every_none_groups',
+    case: 'AND of OR groups mixing posts_every and posts_none',
+    where: {
+      AND: [
+        {
+          OR: [
+            { posts_every: { content: 'Hello' } },
+            { posts_none: { content: 'World' } },
+          ],
+        },
+        {
+          OR: [
+            { posts_every: { content: 'Bye' } },
+            { posts_none: { content: 'Hello' } },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Charlie', 'David'],
+  },
+
+  {
+    id: 'or_of_every_none_contradictions',
+    case: 'OR of contradictory every+none pairs should still only match empty relationship',
+    where: {
+      OR: [
+        {
+          AND: [
+            { posts_every: { content: 'Hello' } },
+            { posts_none: { content: 'Hello' } },
+          ],
+        },
+        {
+          AND: [
+            { posts_every: { content: 'World' } },
+            { posts_none: { content: 'World' } },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['David'],
+  },
+
+  {
+    id: 'and_some_every_none_triplet',
+    case: 'Triplet: some + every + none on same relationship',
+    where: {
+      AND: [
+        {
+          posts_some: {
+            OR: [{ content: 'Hello' }, { content: 'World' }, { content: 'Bye' }],
+          },
+        },
+        {
+          posts_every: {
+            OR: [{ content: 'Hello' }, { content: 'World' }],
+          },
+        },
+        { posts_none: { content: 'World' } },
+      ],
+    },
+    expect_ids: ['Bob'],
+  },
+
+  {
+    id: 'or_every_none_with_scalar_guards',
+    case: 'Scalar guards should stay branch-local around every/none relationship filters',
+    where: {
+      OR: [
+        {
+          AND: [
+            { name: 'Alice' },
+            { posts_every: { content: 'Hello' } },
+          ],
+        },
+        {
+          AND: [
+            { name: 'Charlie' },
+            { posts_none: { content: 'Hello' } },
+          ],
+        },
+        {
+          AND: [
+            { name: 'David' },
+            { posts_every: { content: 'Hello' } },
+            { posts_none: { content: 'Hello' } },
+          ],
+        },
+      ],
+    },
+    expect_ids: ['Charlie', 'David'],
+  },
+
+  {
+    id: 'and_nested_or_every_none_with_name_guard',
+    case: 'Nested OR every/none group combined with scalar name guard',
+    where: {
+      AND: [
+        {
+          OR: [
+            { posts_every: { content: 'Hello' } },
+            { posts_none: { content: 'World' } },
+          ],
+        },
+        {
+          OR: [{ name: 'Alice' }, { name: 'Bob' }],
+        },
+      ],
+    },
+    expect_ids: ['Bob'],
+  },
+];
+
 const setupKeystone = adapterName =>
   setupServer({
     adapterName,
@@ -1178,6 +1598,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         ...moreAndOrFilterTests,
         ...deepAndOrFilterTests,
         ...divergenceAndOrFilterTests,
+        ...quantifierAndOrDivergenceTests,
       ];
       cases.forEach(({ id, case: title, where, expect_ids, ...expected }) => {
         test(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Filter semantics” guide section describing GraphQL `where` boolean evaluation, empty/identity behaviors, and relationship quantifier rules (`some`/`none`/`every`).
* **Bug Fixes**
  * Improved consistent evaluation of complex nested `AND`/`OR` filters and relationship predicates across adapters, including correct handling of empty sub-filters.
  * Tightened GraphQL `where` schema validation for `AND`/`OR` array contents.
* **Tests**
  * Added comprehensive end-to-end coverage for complex boolean and relationship filter cases across adapters, and updated parser/schema expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->